### PR TITLE
fix scroll to hash not working

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import ScrollToHash from '@/components/ScrollToHash';
 import { notFound } from 'next/navigation'
 import { CustomMDX } from '@/components/mdx'
 import { getPosts } from '@/app/utils/utils'
@@ -144,6 +145,7 @@ export default function Blog({ params }: BlogParams) {
 				fillWidth>
 				<CustomMDX source={post.content} />
 			</Flex>
+			<ScrollToHash />
 		</Flex>
 	)
 }

--- a/src/app/[locale]/work/[slug]/page.tsx
+++ b/src/app/[locale]/work/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { routing } from '@/i18n/routing';
 import { unstable_setRequestLocale } from 'next-intl/server';
 import { useTranslations } from 'next-intl';
 import { formatDate } from '@/app/utils/formatDate';
+import ScrollToHash from '@/components/ScrollToHash';
 
 interface WorkParams {
     params: {
@@ -163,6 +164,7 @@ export default function Project({ params }: WorkParams) {
 				</Flex>
 				<CustomMDX source={post.content} />
 			</Flex>
+			<ScrollToHash />
 		</Flex>
 	)
 }

--- a/src/components/ScrollToHash.tsx
+++ b/src/components/ScrollToHash.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function ScrollToHash() {
+    const router = useRouter();
+
+    useEffect(() => {
+        // Get the hash from the URL
+        const hash = window.location.hash;
+        if (hash) {
+            // Remove the '#' symbol
+            const id = hash.replace('#', '');
+            const element = document.getElementById(id);
+            if (element) {
+                element.scrollIntoView({ behavior: 'smooth' });
+            }
+        }
+    }, [router]);
+
+    return null;
+} 


### PR DESCRIPTION
This is a fix for #20 .

I believe its trying to scroll before the element present in the DOM.  Added a `ScrollToHash` client component that scrolls to the target element based on the URL hash.

Great work on once ui btw.
