### PR TITLE
feat: dynamic sitemap generator using config routes

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,28 +3,28 @@ import { baseURL, routes as routesConfig } from '@/app/resources'
 import { routing } from '@/i18n/routing'
 
 export default async function sitemap() {
-
     const locales = routing.locales;
+    const includeLocalePrefix = locales.length > 1;
 
     let blogs = locales.flatMap((locale) => 
         getPosts(['src', 'app', '[locale]', 'blog', 'posts', locale]).map((post) => ({
-            url: `${baseURL}/${locale}/blog/${post.slug}`,
+            url: `${baseURL}${includeLocalePrefix ? `/${locale}` : ''}/blog/${post.slug}`,
             lastModified: post.metadata.publishedAt,
         }))
     );
 
     let works = locales.flatMap((locale) => 
         getPosts(['src', 'app', '[locale]', 'work', 'projects', locale]).map((post) => ({
-            url: `${baseURL}/${locale}/work/${post.slug}`,
+            url: `${baseURL}${includeLocalePrefix ? `/${locale}` : ''}/work/${post.slug}`,
             lastModified: post.metadata.publishedAt,
         }))
     );
 
-    const activeRoutes  = Object.keys(routesConfig).filter((route) => routesConfig[route]);
+    const activeRoutes = Object.keys(routesConfig).filter((route) => routesConfig[route]);
 
     let routes = locales.flatMap((locale)=> 
         activeRoutes.map((route) => ({
-            url: `${baseURL}/${locale}${route !== '/' ? route : ''}`,
+            url: `${baseURL}${includeLocalePrefix ? `/${locale}` : ''}${route !== '/' ? route : ''}`,
             lastModified: new Date().toISOString().split('T')[0],
         }))
     );

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import { getPosts } from '@/app/utils/utils'
-import { baseURL } from '@/app/resources'
+import { baseURL, routes as routesConfig } from '@/app/resources'
 import { routing } from '@/i18n/routing'
 
 export default async function sitemap() {
@@ -20,8 +20,10 @@ export default async function sitemap() {
         }))
     );
 
+    const activeRoutes  = Object.keys(routesConfig).filter((route) => routesConfig[route]);
+
     let routes = locales.flatMap((locale)=> 
-        ['', '/blog', '/work'].map((route) => ({
+        activeRoutes.map((route) => ({
             url: `${baseURL}/${locale}${route}`,
             lastModified: new Date().toISOString().split('T')[0],
         }))

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -24,7 +24,7 @@ export default async function sitemap() {
 
     let routes = locales.flatMap((locale)=> 
         activeRoutes.map((route) => ({
-            url: `${baseURL}/${locale}${route}`,
+            url: `${baseURL}/${locale}${route !== '/' ? route : ''}`,
             lastModified: new Date().toISOString().split('T')[0],
         }))
     );


### PR DESCRIPTION
### Objective

- the sitemap should conatin all of the active routes defined in the config
- it should not include the routes that are false
- when a new route is added to the config, the sitemap does not need to be hard coded


### Tested

here is the sitemap with all the routes in config set to true:

```
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 <url>
  <loc>demo.magic-portfolio.com/en</loc>
  <lastmod>2024-12-12</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/about</loc>
  <lastmod>2024-12-12</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/work</loc>
  <lastmod>2024-12-12</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/blog</loc>
  <lastmod>2024-12-12</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/gallery</loc>
  <lastmod>2024-12-12</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/blog/new-milestone-in-my-career</loc>
  <lastmod>2024-04-08</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/blog/the-99-percent-that-remains-in-the-drawer</loc>
  <lastmod>2024-03-05</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/blog/the-rise-of-design-engineering</loc>
  <lastmod>2024-03-05</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/work/automate-design-handovers-with-a-figma-to-code-pipeline</loc>
  <lastmod>2024-04-01</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/work/building-once-ui-a-customizable-design-system</loc>
  <lastmod>2024-04-08</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/work/simple-portfolio-builder</loc>
  <lastmod>2024-04-08</lastmod>
 </url>
</urlset>
```

Here is the sitemap when all of the routes apart from '/' are toggled off:
```
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 <url>
  <loc>demo.magic-portfolio.com/en</loc>
  <lastmod>2024-12-12</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/blog/new-milestone-in-my-career</loc>
  <lastmod>2024-04-08</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/blog/the-99-percent-that-remains-in-the-drawer</loc>
  <lastmod>2024-03-05</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/blog/the-rise-of-design-engineering</loc>
  <lastmod>2024-03-05</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/work/automate-design-handovers-with-a-figma-to-code-pipeline</loc>
  <lastmod>2024-04-01</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/work/building-once-ui-a-customizable-design-system</loc>
  <lastmod>2024-04-08</lastmod>
 </url>
 <url>
  <loc>demo.magic-portfolio.com/en/work/simple-portfolio-builder</loc>
  <lastmod>2024-04-08</lastmod>
 </url>
</urlset>
```

Note how the work and blog pages are still included because they are generated by files in the relevant directory and therefore shouldn't be altered by the config.