### PR TITLE
fix: ensure valid locale and fallback to default in request configuration

### DIFF
--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,12 +1,17 @@
-import {notFound} from 'next/navigation';
-import {getRequestConfig} from 'next-intl/server';
-import {routing} from './routing';
- 
-export default getRequestConfig(async ({locale}) => {
-  // Validate that the incoming `locale` parameter is valid
-  if (!routing.locales.includes(locale as any)) notFound();
- 
+import { getRequestConfig } from "next-intl/server";
+import { routing } from "./routing";
+
+export default getRequestConfig(async ({ requestLocale }) => {
+  // This typically corresponds to the `[locale]` segment
+  let locale = await requestLocale;
+
+  // Ensure that the incoming locale is valid
+  if (!locale || !routing.locales.includes(locale as any)) {
+    locale = routing.defaultLocale;
+  }
+
   return {
-    messages: (await import(`../../messages/${locale}.json`)).default
+    locale,
+    messages: (await import(`../../messages/${locale}.json`)).default,
   };
 });


### PR DESCRIPTION
This pull request includes a significant change to the `src/i18n/request.ts` file, focusing on improving the locale validation and configuration process. The most important changes include modifying the locale validation logic and ensuring a default locale is used when the incoming locale is invalid.

![image](https://github.com/user-attachments/assets/1252701a-e488-4431-aea7-fc9acc07637e)
https://next-intl.dev/blog/next-intl-3-22#await-request-locale

Improvements to locale validation and configuration:

* [`src/i18n/request.ts`](diffhunk://#diff-9e16e573762332d08dd81f11bf42e6f005c91cbdef8ac89d806f9dffa003983fL1-R15): Changed the parameter name from `locale` to `requestLocale` and added logic to handle cases where the locale is invalid or not provided by setting it to the default locale.
* [`src/i18n/request.ts`](diffhunk://#diff-9e16e573762332d08dd81f11bf42e6f005c91cbdef8ac89d806f9dffa003983fL1-R15): Ensured that the `locale` is always included in the returned configuration object, along with the corresponding messages.