### PR TITLE
fix: update studies title to use translation function

### DIFF
--- a/src/app/resources/content-i18n.js
+++ b/src/app/resources/content-i18n.js
@@ -101,7 +101,7 @@ const createI18nContent = (t) => {
         },
         studies: {
             display: true, // set to false to hide this section
-            title: 'Studies',
+            title: t("about.studies.title"),
             institutions: [
                 {
                     name: 'University of Jakarta',


### PR DESCRIPTION
This pull request includes a change to the `src/app/resources/content-i18n.js` file to improve internationalization support. The change involves using a translation function for the title of the "Studies" section.

Internationalization improvements:

* [`src/app/resources/content-i18n.js`](diffhunk://#diff-061412082b94bf316be0bb9891c853be15f67479bc668b165dcef09a04b765f6L104-R104): Replaced the hardcoded title 'Studies' with a translation function call `t("about.studies.title")` to support multiple languages.