### PR TITLE
feat(core): add a link display on project cards

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -76,6 +76,7 @@
         "description": "A photo collection by {name}"
     },
     "projectCard": {
-        "label": "Read Case Study"
+        "label": "Read Case Study",
+        "link": "Project Link"
     }
 }

--- a/src/app/[locale]/work/projects/en/automate-design-handovers-with-a-figma-to-code-pipeline.mdx
+++ b/src/app/[locale]/work/projects/en/automate-design-handovers-with-a-figma-to-code-pipeline.mdx
@@ -10,6 +10,7 @@ team:
     role: "Software Engineer"
     avatar: "/images/avatar.jpg"
     linkedIn: "https://www.linkedin.com/company/once-ui/"
+link: "https://once-ui.com/"
 ---
 
 ## Overview

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -17,6 +17,7 @@ type Metadata = {
     images: string[];
     tag?: string;
     team: Team[];
+    link?: string;
 };
 
 function getMDXFiles(dir: string) {
@@ -43,6 +44,7 @@ function readMDXFile(filePath: string) {
         images: data.images || [],
         tag: data.tag || [],
         team: data.team || [],
+        link: data.link || '',
     };
 
     return { metadata, content };

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -11,6 +11,7 @@ interface ProjectCardProps {
     content: string;
     description: string;
     avatars: { src: string }[];
+    link: string;
 }
 
 export const ProjectCard: React.FC<ProjectCardProps> = ({
@@ -19,7 +20,8 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
     title,
     content,
     description,
-    avatars
+    avatars,
+    link,
 }) => {
     const [activeIndex, setActiveIndex] = useState(0);
     const [isTransitioning, setIsTransitioning] = useState(false);
@@ -87,8 +89,8 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
                             key={index}
                             onClick={() => handleControlClick(index)}
                             style={{
-                                background: activeIndex === index 
-                                    ? 'var(--neutral-on-background-strong)' 
+                                background: activeIndex === index
+                                    ? 'var(--neutral-on-background-strong)'
                                     : 'var(--neutral-alpha-medium)',
                                 cursor: 'pointer',
                                 transition: 'background 0.3s ease',
@@ -130,6 +132,14 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
                                 onBackground="neutral-weak">
                                 {description}
                             </Text>
+                        )}
+                        {link && (
+                            <SmartLink
+                                suffixIcon="arrowUpRightFromSquare"
+                                style={{ margin: "0", width: "fit-content" }}
+                                href={link}>
+                                <Text variant="body-default-s">{t("projectCard.link")}</Text>
+                            </SmartLink>
                         )}
                         {content?.trim() && (
                             <SmartLink

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -133,25 +133,27 @@ export const ProjectCard: React.FC<ProjectCardProps> = ({
                                 {description}
                             </Text>
                         )}
-                        {link && (
-                            <SmartLink
-                                suffixIcon="arrowUpRightFromSquare"
-                                style={{ margin: "0", width: "fit-content" }}
-                                href={link}>
-                                <Text variant="body-default-s">{t("projectCard.link")}</Text>
-                            </SmartLink>
-                        )}
-                        {content?.trim() && (
-                            <SmartLink
-                                suffixIcon="chevronRight"
-                                style={{margin: '0', width: 'fit-content'}}
-                                href={href}>
-                                    <Text
-                                        variant="body-default-s">
-                                       {t("projectCard.label")}
-                                    </Text>
-                            </SmartLink>
-                        )}
+                        <Flex gap="24" wrap>
+                            {content?.trim() && (
+                                <SmartLink
+                                    suffixIcon="arrowRight"
+                                    style={{margin: '0', width: 'fit-content'}}
+                                    href={href}>
+                                        <Text
+                                            variant="body-default-s">
+                                        {t("projectCard.label")}
+                                        </Text>
+                                </SmartLink>
+                            )}
+                            {link && (
+                                <SmartLink
+                                    suffixIcon="arrowUpRightFromSquare"
+                                    style={{ margin: "0", width: "fit-content" }}
+                                    href={link}>
+                                    <Text variant="body-default-s">{t("projectCard.link")}</Text>
+                                </SmartLink>
+                            )}
+                        </Flex>
                     </Flex>
                 )}
             </Flex>

--- a/src/components/work/Projects.tsx
+++ b/src/components/work/Projects.tsx
@@ -31,7 +31,9 @@ export function Projects({ range, locale }: ProjectsProps) {
                     title={post.metadata.title}
                     description={post.metadata.summary}
                     content={post.content}
-                    avatars={post.metadata.team?.map((member) => ({ src: member.avatar })) || []}/>
+                    avatars={post.metadata.team?.map((member) => ({ src: member.avatar })) || []}
+                    link={post.metadata.link || ""}
+                />
             ))}
         </Flex>
     );

--- a/src/once-ui/icons.ts
+++ b/src/once-ui/icons.ts
@@ -16,9 +16,11 @@ import {
 	HiExclamationCircle,
 	HiCheckCircle,
 	HiMiniGlobeAsiaAustralia,
+	HiArrowTopRightOnSquare,
 	HiEnvelope,
 	HiCalendarDays,
-	HiClipboard
+	HiClipboard,
+	HiArrowRight
 } from "react-icons/hi2";
 
 import {
@@ -34,17 +36,17 @@ import {
 	FaGithub,
 	FaLinkedin,
 	FaXTwitter,
-	FaArrowUpRightFromSquare
 } from "react-icons/fa6";
 
 export const iconLibrary: Record<string, IconType> = {
 	chevronUp: HiChevronUp,
-    chevronDown: HiChevronDown,
+  chevronDown: HiChevronDown,
 	chevronRight: HiChevronRight,
 	chevronLeft: HiChevronLeft,
 	refresh: HiOutlineArrowPath,
 	arrowUpRight: HiArrowUpRight,
 	check: HiCheck,
+	arrowRight: HiArrowRight,
 	helpCircle: HiMiniQuestionMarkCircle,
 	infoCircle: HiInformationCircle,
 	warningTriangle: HiExclamationTriangle,
@@ -65,5 +67,5 @@ export const iconLibrary: Record<string, IconType> = {
 	linkedin: FaLinkedin,
 	x: FaXTwitter,
 	clipboard: HiClipboard,
-	arrowUpRightFromSquare: FaArrowUpRightFromSquare
+	arrowUpRightFromSquare: HiArrowTopRightOnSquare
 };

--- a/src/once-ui/icons.ts
+++ b/src/once-ui/icons.ts
@@ -33,7 +33,8 @@ import {
 	FaDiscord,
 	FaGithub,
 	FaLinkedin,
-	FaXTwitter
+	FaXTwitter,
+	FaArrowUpRightFromSquare
 } from "react-icons/fa6";
 
 export const iconLibrary: Record<string, IconType> = {
@@ -63,5 +64,6 @@ export const iconLibrary: Record<string, IconType> = {
 	github: FaGithub,
 	linkedin: FaLinkedin,
 	x: FaXTwitter,
-	clipboard: HiClipboard
+	clipboard: HiClipboard,
+	arrowUpRightFromSquare: FaArrowUpRightFromSquare
 };


### PR DESCRIPTION
I wanted to add clickable link to projects, I didn't found a way to do it.
Now there's a link display in the project card when the project .mdx contains a `link`.

<img width="961" alt="image" src="https://github.com/user-attachments/assets/0ebeff3b-8b9c-4adc-b8bb-59d1e736f55c" />

Feel free to change the used icon or placement in the project card.

P.S. didn't found a contributing, tell me if you have any question