### PR TITLE
Move password to .env file for better security and easier management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,6 @@
 # NEXT_PUBLIC_API_KEY=your_api_key_here
 # DATABASE_URL=your_database_url_here
 # SECRET_KEY=your_secret_key_here
+
+# Password for protected pages/routes
+PAGE_ACCESS_PASSWORD=password

--- a/src/app/resources/config.js
+++ b/src/app/resources/config.js
@@ -9,7 +9,7 @@ const routes = {
 };
 
 // Enable password protection on selected routes
-// Set password in pages/api/authenticate.ts
+// Set password in the .env file, refer to .env.example
 const protectedRoutes = {
   "/work/automate-design-handovers-with-a-figma-to-code-pipeline": true,
 };

--- a/src/components/RouteGuard.tsx
+++ b/src/components/RouteGuard.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { routes, protectedRoutes } from "@/app/resources";
-import { Flex, Spinner, Input, Button, Heading, Column } from "@/once-ui/components";
+import { Flex, Spinner, Input, Button, Heading, Column, PasswordInput } from "@/once-ui/components";
 
 interface RouteGuardProps {
   children: React.ReactNode;
@@ -98,10 +98,9 @@ const RouteGuard: React.FC<RouteGuardProps> = ({ children }) => {
           This page is password protected
         </Heading>
         <Column fillWidth gap="8" horizontal="center">
-          <Input
+          <PasswordInput
             id="password"
             label="Password"
-            type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             errorMessage={error}

--- a/src/once-ui/icons.ts
+++ b/src/once-ui/icons.ts
@@ -21,6 +21,8 @@ import {
   HiCalendarDays,
   HiClipboard,
   HiArrowRight,
+  HiOutlineEye,
+  HiOutlineEyeSlash,
 } from "react-icons/hi2";
 
 import {
@@ -58,6 +60,8 @@ export const iconLibrary: Record<string, IconType> = {
   home: PiHouseDuotone,
   gallery: PiImageDuotone,
   discord: FaDiscord,
+  eye: HiOutlineEye,
+  eyeOff: HiOutlineEyeSlash,
   github: FaGithub,
   linkedin: FaLinkedin,
   x: FaXTwitter,

--- a/src/pages/api/authenticate.ts
+++ b/src/pages/api/authenticate.ts
@@ -4,7 +4,12 @@ import * as cookie from "cookie";
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === "POST") {
     const { password } = req.body;
-    const correctPassword = "password";
+    const correctPassword = process.env.PAGE_ACCESS_PASSWORD;
+
+    if (!correctPassword) {
+      console.error('PAGE_ACCESS_PASSWORD environment variable is not set');
+      return res.status(500).json({ message: "Internal server error" });
+    }
 
     if (password === correctPassword) {
       res.setHeader(


### PR DESCRIPTION
Replacing the hardcoded password with an environment variable (PAGE_ACCESS_PASSWORD).

Changes:

1. Updated .env.example to include PAGE_ACCESS_PASSWORD.
2. Modified authenticate.ts to use process.env.PAGE_ACCESS_PASSWORD instead of a hardcoded value. Added error message if password is not set in env file.
3. Updated the comment in config.js to point the user to the env file (instead of authenticate.ts) 

May need to update the README to include instructions on setting up the `.env` file, or leave it out since a missing password only triggers a server error prompting to set it first. It doesn’t affect the frontend user experience, that simply keeps displaying "Wrong password.