### PR TITLE
BugFix: Missing protocole on sitemap loc fields

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,19 +3,19 @@ import { baseURL, routes as routesConfig } from "@/app/resources";
 
 export default async function sitemap() {
   const blogs = getPosts(["src", "app", "blog", "posts"]).map((post) => ({
-    url: `${baseURL}/blog/${post.slug}`,
+    url: `https://${baseURL}/blog/${post.slug}`,
     lastModified: post.metadata.publishedAt,
   }));
 
   const works = getPosts(["src", "app", "work", "projects"]).map((post) => ({
-    url: `${baseURL}/work/${post.slug}`,
+    url: `https://${baseURL}/work/${post.slug}`,
     lastModified: post.metadata.publishedAt,
   }));
 
   const activeRoutes = Object.keys(routesConfig).filter((route) => routesConfig[route]);
 
   const routes = activeRoutes.map((route) => ({
-    url: `${baseURL}${route !== "/" ? route : ""}`,
+    url: `https://${baseURL}${route !== "/" ? route : ""}`,
     lastModified: new Date().toISOString().split("T")[0],
   }));
 


### PR DESCRIPTION
I haven't opened an issue for this bug, but when I've tried to add my sitemap to Google Search Console I had an error about the loc field. I fixed it by adding the protocol to the loc urls.