### PR TITLE
fix: TypeError: publishedAt

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -104,7 +104,7 @@ export default function Blog({ params }: BlogParams) {
       <Row gap="12" vertical="center">
         {avatars.length > 0 && <AvatarGroup size="s" avatars={avatars} />}
         <Text variant="body-default-s" onBackground="neutral-weak">
-          {formatDate(post.metadata.publishedAt)}
+          {post.metadata.publishedAt && formatDate(post.metadata.publishedAt)}
         </Text>
       </Row>
       <Column as="article" fillWidth>

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -118,7 +118,7 @@ export default function Project({ params }: WorkParams) {
         <Flex gap="12" marginBottom="24" vertical="center">
           {post.metadata.team && <AvatarGroup reverse avatars={avatars} size="m" />}
           <Text variant="body-default-s" onBackground="neutral-weak">
-            {formatDate(post.metadata.publishedAt)}
+            {post.metadata.publishedAt && formatDate(post.metadata.publishedAt)}
           </Text>
         </Flex>
         <CustomMDX source={post.content} />

--- a/src/components/blog/Post.tsx
+++ b/src/components/blog/Post.tsx
@@ -45,7 +45,7 @@ export default function Post({ post, thumbnail }: PostProps) {
             {post.metadata.title}
           </Heading>
           <Text variant="label-default-s" onBackground="neutral-weak">
-            {formatDate(post.metadata.publishedAt, false)}
+            {post.metadata.publishedAt && formatDate(post.metadata.publishedAt, false)}
           </Text>
           {post.metadata.tag && (
             <Tag className="mt-8" label={post.metadata.tag} variant="neutral" />


### PR DESCRIPTION
<img width="1036" alt="error" src="https://github.com/user-attachments/assets/93f9ec0a-93af-4e34-9200-46fa097fe114" />

When `publishedAt` is missing from the blog post and work project metadata, the application crashes with the error:  
`TypeError: Cannot read properties of undefined (reading 'includes')`. 


This happens because another component that processes the date assumes `publishedAt` is always present. While other fields like `team, summary` are optional.

**Steps to Reproduce:**  
> For blog posts:
1. Remove `publishedAt` from the blog metadata.  
2. Load the blog page. (which does not have `publishedAt`)
3. Observe the application crash with the error.  

> For work projects:
1. Remove `publishedAt` from the work metadata.  
2. Navigate to any work project page. (which does not have `publishedAt`)
3. Observe the application crash with the error.  

