### PR TITLE
fix: Handle Missing Tags and Multi-tag Rendering in Blog Posts

### DIFF
--- a/src/components/blog/Post.tsx
+++ b/src/components/blog/Post.tsx
@@ -10,6 +10,8 @@ interface PostProps {
 }
 
 export default function Post({ post, thumbnail }: PostProps) {
+  const tags = post.metadata.tag.split(",").map((tag: string) => tag.trim());
+
   return (
     <SmartLink
       fillWidth
@@ -47,8 +49,12 @@ export default function Post({ post, thumbnail }: PostProps) {
           <Text variant="label-default-s" onBackground="neutral-weak">
             {formatDate(post.metadata.publishedAt, false)}
           </Text>
-          {post.metadata.tag && (
-            <Tag className="mt-8" label={post.metadata.tag} variant="neutral" />
+          {tags.length > 0 && (
+            <Flex gap="8">
+              {tags.map((tag: string, index: number) =>
+                index < 3 ? <Tag key={index} label={tag} variant="neutral" /> : null
+              )}
+            </Flex>
           )}
         </Column>
       </Flex>


### PR DESCRIPTION
<img width="1103" alt="Screenshot 2025-03-01 at 9 50 17 PM" src="https://github.com/user-attachments/assets/135ad27f-3992-43c9-8dbc-039b2a90f845" />

# Handle Missing and Multiple Tags in Blog Posts

## Description

This PR fixes missing tag issues and adds support for multiple tags in blog posts.

### Fixes & Features

1. _Bug Fix:_ Prevents errors when the tag key is missing or empty in metadata.
2. _Feature Addition:_ Supports multiple tags (comma-separated), rendering up to 3 tags for clarity.

### Implementation

- Checks for post.metadata.tag before rendering to prevent UI errors.
- Splits multiple tags and displays only the first 3.

### Example

#### Single Tag

tag: "Journal"

> _Renders:_
> Journal

#### Multiple Tags

tag: "Journal, Career, Growth, Reflection"

> _Renders:_
> Journal, Career, Growth

### Testing

- Verified missing tags, single tag, and multi-tag cases.

### File changes

_File Path:_ src/component/blog/Post.tsx

## Add multiple Tags

<img width="838" alt="Screenshot 2025-03-01 at 9 51 32 PM" src="https://github.com/user-attachments/assets/ffae700d-725f-46a7-b44b-0314b05be379" />

<img width="1079" alt="Screenshot 2025-03-01 at 9 52 54 PM" src="https://github.com/user-attachments/assets/60cdda6e-71b8-4066-9910-c7d7b73fade8" />



