### PR TITLE
fix: Malformed Sitemap URL in robots.txt

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -7,6 +7,6 @@ export default function robots() {
         userAgent: "*",
       },
     ],
-    sitemap: `${baseURL}/sitemap.xml`,
+    sitemap: `https://${baseURL}/sitemap.xml`,
   };
 }


### PR DESCRIPTION
Hi, thank you very much for your great work!

In this PR, I added `https://` to the sitemap URL since sitemap in robots.txt must be a fully qualified URL.
cf. https://developers.google.com/search/docs/crawling-indexing/robots/create-robots-txt#create_rules

↓ This is an error from Chrome Lighthouse (before fix):

<img width="544" alt="Screenshot 2025-03-22 at 17 40 35" src="https://github.com/user-attachments/assets/78bf305c-fb09-4690-bbbf-99c0efec1027" />

↓ and after fix:

<img width="544" alt="Screenshot 2025-03-22 at 17 51 38" src="https://github.com/user-attachments/assets/96249dab-2e15-4607-8fd1-666a64abf0a3" />