### PR TITLE
feat: add custom font support with Inter as default

### DIFF
--- a/src/app/resources/config.js
+++ b/src/app/resources/config.js
@@ -1,3 +1,5 @@
+const { fontConfig } = require('./fonts')
+
 const baseURL = "demo.magic-portfolio.com";
 
 const routes = {
@@ -24,6 +26,7 @@ const style = {
   border: "playful", // rounded | playful | conservative
   surface: "translucent", // filled | translucent
   transition: "all", // all | micro | macro
+  fonts: fontConfig
 };
 
 const effects = {

--- a/src/app/resources/fonts.ts
+++ b/src/app/resources/fonts.ts
@@ -1,0 +1,19 @@
+import localFont from 'next/font/local'
+
+// Font configuration
+export const fontConfig = {
+  primary: {
+    name: "Inter",
+    src: "/fonts/Inter.ttf",
+    variable: "font-primary",
+    display: "swap" as const
+  },
+  fallback: "system-ui, -apple-system, sans-serif"
+} as const
+
+// Font loader - using Inter as the default example
+export const primary = localFont({
+  src: '../../../public/fonts/Inter.ttf',
+  variable: '--font-primary',
+  display: 'swap'
+})


### PR DESCRIPTION
Add support for custom fonts through a configuration system that allows users to easily customize their portfolio's typography.

**Changes:**

- Create fonts.ts configuration module for centralized font management
- Implement font loader with Inter as the default font
- Add font configuration to the style system
- Integrate with existing configuration structure

**This enhancement allows users to:**

- Configure custom fonts through a simple configuration interface
- Maintain consistent typography across the portfolio
- Easily switch between different fonts without code changes
- Example implementation uses Inter as the default font to demonstrate the functionality while maintaining the clean design of Magic Portfolio.

Here is the example screenshot (using [Maple-Mono](https://github.com/subframe7536/maple-font) as main font):
![image](https://github.com/user-attachments/assets/3d315389-38b8-4ebc-9b46-972c0bd820d3)
