### PR TITLE
feat: add theme toggle functionality with sun/moon icons

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { Fade, Flex, Line, ToggleButton } from "@/once-ui/components";
+import { ThemeToggle } from "./ThemeToggle";
 import styles from "@/components/Header.module.scss";
 
 import { routes, display } from "@/app/resources";
@@ -135,14 +136,15 @@ export const Header = () => {
                     label={gallery.label}
                     selected={pathname.startsWith("/gallery")}
                   />
-                  <ToggleButton
-                    className="s-flex-show"
-                    prefixIcon="gallery"
-                    href="/gallery"
-                    selected={pathname.startsWith("/gallery")}
-                  />
-                </>
-              )}
+                <ToggleButton
+                  className="s-flex-show"
+                  prefixIcon="gallery"
+                  href="/gallery"
+                  selected={pathname.startsWith("/gallery")}
+                />
+              </>
+            )}
+            <ThemeToggle />
             </Flex>
           </Flex>
         </Flex>

--- a/src/components/ThemeToggle.module.scss
+++ b/src/components/ThemeToggle.module.scss
@@ -1,0 +1,10 @@
+.button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  
+  svg {
+    width: 1em;
+    height: 1em;
+  }
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import React from 'react';
+import { useTheme } from '@/once-ui/hooks/useTheme';
+import { ToggleButton, Line } from '@/once-ui/components';
+
+export const ThemeToggle: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
+  
+  return (
+    <>
+      <Line vert maxHeight="24" />
+      <ToggleButton
+        prefixIcon={theme === 'light' ? 'sun' : 'moon'}
+        onClick={toggleTheme}
+        selected={false}
+        aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      />
+    </>
+  );
+};

--- a/src/once-ui/hooks/useTheme.ts
+++ b/src/once-ui/hooks/useTheme.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { style } from '@/app/resources';
+
+export function useTheme() {
+  const [theme, setTheme] = useState(style.theme);
+
+  // Load theme from localStorage on mount
+  useEffect(() => {
+    const savedTheme = localStorage.getItem('theme');
+    if (savedTheme) {
+      setTheme(savedTheme);
+      document.documentElement.setAttribute('data-theme', savedTheme);
+    }
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    const newTheme = theme === 'dark' ? 'light' : 'dark';
+    setTheme(newTheme);
+    document.documentElement.setAttribute('data-theme', newTheme);
+    localStorage.setItem('theme', newTheme);
+  }, [theme]);
+
+  return {
+    theme,
+    toggleTheme
+  };
+}

--- a/src/once-ui/icons.ts
+++ b/src/once-ui/icons.ts
@@ -23,6 +23,8 @@ import {
   HiArrowRight,
   HiOutlineEye,
   HiOutlineEyeSlash,
+  HiMoon,
+  HiSun,
 } from "react-icons/hi2";
 
 import {
@@ -67,4 +69,6 @@ export const iconLibrary: Record<string, IconType> = {
   x: FaXTwitter,
   clipboard: HiClipboard,
   arrowUpRightFromSquare: HiArrowTopRightOnSquare,
+  moon: HiMoon,
+  sun: HiSun,
 };


### PR DESCRIPTION
This commit adds theme switching functionality to the portfolio website.

**Key changes:**
- Add useTheme hook for managing theme state and persistence
- Create ThemeToggle component with sun/moon icons from react-icons/hi2
- Integrate theme toggle button in the Header navigation
- Add theme-related styles and transitions

The theme toggle button appears in the navigation bar and allows users to switch between light and dark modes. Theme preference is stored in localStorage for persistence across sessions.

**Here is an example screenshot:**

![image](https://github.com/user-attachments/assets/57b05699-f2a3-48cb-abfd-0520d17c7507)
