### PR TITLE
Image gaps aren't consistent and stuck together.

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -215,7 +215,7 @@ export default function About() {
                       ))}
                     </Column>
                     {experience.images.length > 0 && (
-                      <Flex fillWidth paddingTop="m" paddingLeft="40" wrap>
+                      <Flex fillWidth paddingTop="m" paddingLeft="40" gap="12" wrap>
                         {experience.images.map((image, index) => (
                           <Flex
                             key={index}


### PR DESCRIPTION
In the work section of the About Me page, if there are multiple images they'll be stuck together because there isn't any gap set. I've set the gap accordingly to the other flex's gap that contains images so they're not stuck together and they look consistent across the page.

Before:
![Screenshot From 2025-05-12 19-05-07](https://github.com/user-attachments/assets/1dc6f4b0-c31d-4cbe-bfca-b1bf48935d7f)

After:
![Screenshot From 2025-05-12 19-05-25](https://github.com/user-attachments/assets/dead07bb-0373-43fe-9c4a-ac64e14a007b)
