### PR TITLE
fix: logo displays correctly in light/dark mode

### DIFF
--- a/src/components/BrandLogo.tsx
+++ b/src/components/BrandLogo.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Logo, useTheme } from '@once-ui-system/core';
+
+export default function BrandLogo() {
+
+    const { theme } = useTheme();
+
+    return (
+        <Logo
+            dark={theme === "dark"}
+            light={theme === "light"}
+            icon={
+                theme === "light"
+                    ? "/trademarks/wordmark-light.svg"
+                    : "/trademarks/wordmark-dark.svg"
+            }
+            style={{
+                display: "inline-flex",
+                top: "0.25em",
+                marginLeft: "-0.25em",
+            }}
+        />
+    )
+}

--- a/src/resources/content.tsx
+++ b/src/resources/content.tsx
@@ -1,3 +1,4 @@
+import BrandLogo from "@/components/BrandLogo";
 import { About, Blog, Gallery, Home, Newsletter, Person, Social, Work } from "@/types";
 import { Line, Logo, Row, Text } from "@once-ui-system/core";
 
@@ -66,11 +67,7 @@ const home: Home = {
   subline: (
     <>
       I'm Selene, a design engineer at{" "}
-      <Logo
-        dark
-        icon="/trademarks/wordmark-dark.svg"
-        style={{ display: "inline-flex", top: "0.25em", marginLeft: "-0.25em" }}
-      />
+      <BrandLogo />
       , where I craft intuitive
       <br /> user experiences. After hours, I build my own projects.
     </>
@@ -223,7 +220,7 @@ const about: About = {
             height: 9,
           },
         ],
-      },  
+      },
     ],
   },
 };


### PR DESCRIPTION
**Summary**
This PR fixes the issue where the logo always displayed the dark version, even when the site was in light mode.

**Changes**
- Added a wrapper component BrandLogo that detects the current theme.
- Updated home.subline to use <BrandLogo />.
- Ensures the correct logo (wordmark-light.svg or wordmark-dark.svg) is shown depending on theme.

**Why**
Previously, the light mode still showed the dark logo, causing a visual inconsistency. This fix improves readability and maintains proper branding across themes.