### PR TITLE
feat: add blog subtitle support

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -101,6 +101,16 @@ export default async function Blog({ params }: { params: Promise<{ slug: string 
               {post.metadata.publishedAt && formatDate(post.metadata.publishedAt)}
             </Text>
             <Heading variant="display-strong-m">{post.metadata.title}</Heading>
+            {post.metadata.subtitle && (
+              <Text 
+                variant="body-default-l" 
+                onBackground="neutral-weak" 
+                align="center"
+                style={{ fontStyle: 'italic' }}
+              >
+                {post.metadata.subtitle}
+              </Text>
+            )}
           </Column>
           <Row marginBottom="32" horizontal="center">
             <Row gap="16" vertical="center">

--- a/src/app/blog/posts/quick-start.mdx
+++ b/src/app/blog/posts/quick-start.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Quick start with Magic Portfolio"
+subtitle: "A comprehensive guide to setting up your professional portfolio in minutes"
 summary: "Magic Portfolio is a comprehensive, MDX-based, SEO-friendly, responsive portfolio template built with Once UI and Next.js."
 image: "/images/gallery/horizontal-1.jpg"
 publishedAt: "2025-04-23"

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -11,6 +11,7 @@ type Team = {
 
 type Metadata = {
   title: string;
+  subtitle?: string;
   publishedAt: string;
   summary: string;
   image?: string;
@@ -40,6 +41,7 @@ function readMDXFile(filePath: string) {
 
   const metadata: Metadata = {
     title: data.title || "",
+    subtitle: data.subtitle || "",
     publishedAt: data.publishedAt,
     summary: data.summary || "",
     image: data.image || "",


### PR DESCRIPTION
- Add optional subtitle field to blog post metadata
- Display subtitle with italic styling below the post title
- Update quick-start.mdx with example subtitle
- Maintain backward compatibility for posts without subtitles