### PR TITLE
feat: add LaTeX support via react-katex

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-dom": "^19.2.0",
     "react-icons": "^5.5.0",
     "sass": "^1.86.3",
-    "transliteration": "^2.3.5"
+    "transliteration": "^2.3.5",
+    "react-katex": "^3.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "@once-ui-system/core/css/styles.css";
 import "@once-ui-system/core/css/tokens.css";
 import "@/resources/custom.css";
+import "katex/dist/katex.min.css";
 
 import classNames from "classnames";
 

--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -1,6 +1,7 @@
 import { MDXRemote, MDXRemoteProps } from "next-mdx-remote/rsc";
 import React, { ReactNode } from "react";
 import { slugify as transliterate } from "transliteration";
+import { BlockMath, InlineMath } from "react-katex";
 
 import {
   Heading,
@@ -202,6 +203,8 @@ const components = {
   Icon,
   Media,
   SmartLink,
+  BlockMath,
+  InlineMath,
 };
 
 type CustomMDXProps = MDXRemoteProps & {


### PR DESCRIPTION
Fixes #150 

## What
Enable LaTeX math support in MDX using react-katex.

## Why
MDX currently does not render inline/block math expressions,
which limits technical documentation use cases.

## How
- Add react-katex to the MDX pipeline
- Import KaTeX CSS

## Example (MDX)

```
ニューラルネットワークにおいて，損失関数はモデルが出力を望ましい目標と比較してどれだけ正確に予測したかを評価する指標である．複素数領域では，複素数は実部と虚部を持つ2次元の数値であるため，直接的な大小比較はできない．一般的な方法は複素数の実部と虚部をそれぞれに対してMSE計算を行うことである．ToFカメラの取得した複素数
<InlineMath math = 'z_{i_k} \in \mathbf{z_i} = \left\{ z_{i_1}, \ldots, z_{i_N} \right\}'/>を入力した際に得られた出力を<InlineMath math ='z_{o_k} \in \mathbf{z_o} = \left\{ z_{o_1}, \ldots, z_{o_N} \right\}'/>とし, 真値を<InlineMath math = '\bar{z}_{o_k}\in \mathbf{\bar{z}_o} = \left\{ \bar{z}_{o_1}, \ldots, \bar{z}_{o_N} \right\}'/>と定義する．ここで，<InlineMath math = 'N'/>はピクセルの総数である．

<BlockMath math="\mathcal{L}= \frac{1}{N}(\sum_{k}^N(|z_{o_k}-\bar{z}_{o_k}|))" />
```
<img width="668" height="298" alt="Screenshot 2025-12-19 at 21 10 25" src="https://github.com/user-attachments/assets/b95e8dab-2b03-4c50-8c24-b52fe80e6651" />